### PR TITLE
passthroughpattern option

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -283,6 +283,13 @@
 #   administrative functionality.
 #   Default: undef
 #
+# [*passthroughpattern*]
+#   Allow data pass-through mode for certain hosts when requested by the client
+#   using a CONNECT request. This is particularly useful to allow access to SSL
+#   sites (https proxying). The string is a regular expression which should cover
+#   the server name with port and must be correctly formated and terminated.
+#   Default: undef
+#
 # === Examples
 #
 #  class { aptcacherng:
@@ -345,6 +352,7 @@ class aptcacherng (
   $allowuserports       = undef,
   $redirmax             = undef,
   $vfileuserangeops     = undef,
+  $passthroughpattern   = undef,
   $auth_username        = undef,
   $auth_password        = undef,
   $service_ensure       = running,

--- a/templates/acng.conf.erb
+++ b/templates/acng.conf.erb
@@ -407,3 +407,14 @@ RedirMax: <%= @redirmax %>
 <% if @vfileuserangeops %>
 VfileUseRangeOps: <%= @vfileuserangeops %>
 <% end %>
+
+# Allow data pass-through mode for certain hosts when requested by the client
+# using a CONNECT request. This is particularly useful to allow access to SSL
+# sites (https proxying). The string is a regular expression which should cover
+# the server name with port and must be correctly formated and terminated.
+#
+# PassThroughPattern: private-ppa\.launchpad\.net:443$
+# PassThroughPattern: .* # this would allow CONNECT to everything
+<% if @passthroughpattern %>
+PassThroughPattern: <%= @passthroughpattern %>
+<% end %>


### PR DESCRIPTION
I needed the PassThroughPattern option for https repos.

If one would need that, he would set: 
```
passthroughpattern => '.*:443$'
```
