### PR TITLE
Add max_files parameter and /etc/security/limits.d/apt-cacher-ng file

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -290,6 +290,10 @@
 #   regular expression which should cover the server name with port
 #   and must be correctly formated and terminated.  Default: undef
 #
+# [*max_files*]
+#   Sets Linux security nofile limit
+#   Default: 1024
+#
 # === Examples
 #
 #  class { aptcacherng:
@@ -357,6 +361,7 @@ class aptcacherng (
   $auth_password        = undef,
   $service_ensure       = running,
   $service_enable       = true,
+  $max_files            = 1024,
   # TODO support an argument for this
   # http://www.unix-ag.uni-kl.de/~bloch/acng/html/howtos.html#howto-importdisk
   ) {
@@ -404,6 +409,14 @@ class aptcacherng (
 
   file {'/etc/apt-cacher-ng/zz_debconf.conf':
     ensure => absent,
+  }
+
+  file {'/etc/security/limits.d/apt-cacher-ng':
+    ensure  => file,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0644',
+    content => "apt-cacher-ng soft nofile ${max_files}\napt-cacher-ng hard nofile ${max_files}",
   }
 
   service {'apt-cacher-ng':


### PR DESCRIPTION
Hi there! We have a few hundred servers hitting our apt-cacher-ng instance and it appears after a little bit that the daemon would start throwing these error logs:

```
Thu Mar 10 11:43:47 2016|Error creating pipe file descriptors
Thu Mar 10 11:43:47 2016|Error creating pipe file descriptors
Thu Mar 10 11:43:48 2016|Error creating pipe file descriptors
Thu Mar 10 11:43:48 2016|Error creating pipe file descriptors
Thu Mar 10 11:43:48 2016|Error creating pipe file descriptors
Thu Mar 10 11:43:48 2016|Error creating pipe file descriptors
Thu Mar 10 11:43:48 2016|Error creating pipe file descriptors
Thu Mar 10 11:43:48 2016|Error creating pipe file descriptors
Thu Mar 10 11:43:48 2016|Error creating pipe file descriptors
Thu Mar 10 11:43:48 2016|Error creating pipe file descriptors
Thu Mar 10 11:43:49 2016|Error creating pipe file descriptors
```

The fix is to raise the Linux security nofile limit for the apt-cacher-ng user so it can allocate more files than the default limit of 1024. I left the default as 1024 in the module here so effectively its a no-op for everyone's environment, but we set ours to 65536 since its on a dedicated server and won't affect other services.